### PR TITLE
ci: add inputs to allow configuring helm actions

### DIFF
--- a/helm-gcs-publish/action.yml
+++ b/helm-gcs-publish/action.yml
@@ -1,15 +1,27 @@
 name: 'Helm GCS Publish'
 description: 'Published helm charts to GCS'
+inputs:
+  chart-path:
+    description: 'Path to helm chart directory'
+    required: true
+    default: './helm'
+  helm-gcs-repository: # Replaces $HELM_GCS_REPOSITORY env var. Assumes only one or other is set
+    description: 'Helm repository GCS URL'
+    required: false
+  helm-gcs-credentials: # Replaces $HELM_GCS_CREDENTIALS env var. Assumes only one or other is set
+    description: 'Credentials for writing to Helm repository'
+    required: false
 runs:
   using: "composite"
   steps: 
     - run: |
           CHART_VERSION=$(echo ${GITHUB_REF} | cut -d/ -f 3)
-          CHART_NAME=$(awk '/^name:/ {print $2}' ./helm/Chart.yaml)
+          CHART_NAME=$(awk '/^name:/ {print $2}' ${{ inputs.chart-path}}/Chart.yaml)
           export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/helm-gcs-key.json
-          echo $HELM_GCS_CREDENTIALS > ${GOOGLE_APPLICATION_CREDENTIALS}
-          helm dependency update ./helm/
-          helm repo add helm-gcs $HELM_GCS_REPOSITORY
-          helm package --version ${CHART_VERSION} --app-version ${CHART_VERSION} ./helm/
+          echo ${HELM_GCS_CREDENTIALS}${{ inputs.helm-gcs-credentials }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          helm dependency update ${{ inputs.chart-path }}
+          TEMP_REPO=${HELM_GCS_REPOSITORY}${{ inputs.helm-gcs-repository }}
+          helm repo add helm-gcs $TEMP_REPO
+          helm package --version ${CHART_VERSION} --app-version ${CHART_VERSION} ${{ inputs.chart-path }}
           helm gcs push ${CHART_NAME}-${CHART_VERSION}.tgz helm-gcs --public --retry
       shell: sh

--- a/helm-gcs-publish/action.yml
+++ b/helm-gcs-publish/action.yml
@@ -17,11 +17,13 @@ runs:
     - run: |
           CHART_VERSION=$(echo ${GITHUB_REF} | cut -d/ -f 3)
           CHART_NAME=$(awk '/^name:/ {print $2}' ${{ inputs.chart-path}}/Chart.yaml)
+          INPUT_REPOSITORY=${{ inputs.helm-gcs-repository }}
+          INPUT_CREDENTIALS=${{ inputs.helm-gcs-credentials }}
           export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/helm-gcs-key.json
-          echo ${HELM_GCS_CREDENTIALS}${{ inputs.helm-gcs-credentials }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+
+          echo ${INPUT_CREDENTIALS:-$HELM_GCS_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
           helm dependency update ${{ inputs.chart-path }}
-          TEMP_REPO=${HELM_GCS_REPOSITORY}${{ inputs.helm-gcs-repository }}
-          helm repo add helm-gcs $TEMP_REPO
+          helm repo add helm-gcs ${INPUT_REPOSITORY:-$HELM_GCS_REPOSITORY}
           helm package --version ${CHART_VERSION} --app-version ${CHART_VERSION} ${{ inputs.chart-path }}
           helm gcs push ${CHART_NAME}-${CHART_VERSION}.tgz helm-gcs --public --retry
       shell: sh

--- a/validate-charts/action.yml
+++ b/validate-charts/action.yml
@@ -1,10 +1,15 @@
 name: 'Validate helm charts'
 description: 'prevalidate helm chart template before its deployment; executes helm lint and helm template commands'
+inputs:
+  chart-path:
+    description: 'Path to helm chart directory'
+    required: true
+    default: './helm'
 runs:
   using: "composite"
   steps: 
     - run: |
-          helm dependency update ./helm/
-          helm lint --strict ./helm/
-          helm template ./helm/
+          helm dependency update ${{ inputs.chart-path }}
+          helm lint --strict ${{ inputs.chart-path }}
+          helm template ${{ inputs.chart-path }}
       shell: sh


### PR DESCRIPTION
## Description
This change adds inputs to change the directory of the helm chart, supporting repositories with multiple charts or alternate layouts. It also sets the stage for moving the two expected helm credentials from env vars to proper inputs (exposing the inputs, but not using them until current consumers have been converted for compatibility)
